### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ If you have multiple organizations, repeat the process starting from step 3 to c
 
 ### Step 3: Configure the Plugin in Mattermost
 
+
+
+
+
 As a System Admin, if you have an existing Mattermost user account with the name `github`, the plugin will post using the `github` account but without a `BOT` tag.
 
 To prevent this, either:


### PR DESCRIPTION
<p>Bumps <a href="https://github.com/npm/hosted-git-info">hosted-git-info</a> from 2.8.8 to 2.8.9. <strong>This update includes a security fix.</strong></p>
