### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Mattermost GitHub Plugin
 
+
+
+
+
+
+
+
+
 [![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-github/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-github)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-github/master.svg)](https://codecov.io/gh/mattermost/mattermost-plugin-github)
 [![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-github)](https://github.com/mattermost/mattermost-plugin-github/releases/latest)


### PR DESCRIPTION
Bumps <a href="https://github.com/npm/hosted-git-info">hosted-git-info</a> from 2.8.8 to 2.8.9. <strong>This update includes a security fix.</strong>